### PR TITLE
Implemented forgot/reset password, improved middleware safety, removed remember me checkbox

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button, Input } from "@/components";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState("");
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setIsLoading(true);
+    setApiError("");
+
+    try {
+      const response = await fetch("/api/auth/forgot-password", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setApiError(data.error || "Failed to send reset email");
+        setIsLoading(false);
+        return;
+      }
+
+      setIsSubmitted(true);
+    } catch (error) {
+      console.error("Forgot password error:", error);
+      setApiError("An unexpected error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-6">
+      <div className="w-full max-w-[420px] animate-slide-up rounded-2xl bg-white p-10 shadow-lg">
+        {/* Brand Header */}
+        <div className="mb-8 text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-black">
+            PrimeTime
+          </h1>
+          <p className="mt-2 text-sm text-gray-500">
+            Prepare. Prime. Perform.
+          </p>
+        </div>
+
+        {isSubmitted ? (
+          /* Success State */
+          <div className="flex flex-col gap-5">
+            <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-center">
+              <p className="text-sm font-medium text-green-800">
+                Check your email
+              </p>
+              <p className="mt-1 text-sm text-green-600">
+                We&apos;ve sent a password reset link to{" "}
+                <span className="font-medium">{email}</span>
+              </p>
+            </div>
+
+            <Link
+              href="/login"
+              className="block text-center text-sm text-gray-600 transition-colors hover:text-black"
+            >
+              Back to login
+            </Link>
+          </div>
+        ) : (
+          /* Forgot Password Form */
+          <>
+            <p className="mb-6 text-center text-sm text-gray-500">
+              Enter your email address and we&apos;ll send you a link to reset
+              your password.
+            </p>
+
+            <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+              {/* API Error Message */}
+              {apiError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+                  {apiError}
+                </div>
+              )}
+
+              {/* Email */}
+              <Input
+                label="Email"
+                type="email"
+                placeholder="student@university.edu"
+                required
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+
+              {/* Submit */}
+              <Button type="submit" fullWidth isLoading={isLoading}>
+                Send Reset Link
+              </Button>
+
+              {/* Back to Login */}
+              <Link
+                href="/login"
+                className="block text-center text-sm text-gray-600 transition-colors hover:text-black"
+              >
+                Back to login
+              </Link>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -12,7 +12,6 @@ export default function LoginPage() {
   const [role, setRole] = useState<Role>("student");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [rememberMe, setRememberMe] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState("");
 
@@ -126,17 +125,6 @@ export default function LoginPage() {
               />
             </div>
           </div>
-
-          {/* Remember Me */}
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={rememberMe}
-              onChange={(e) => setRememberMe(e.target.checked)}
-              className="h-4 w-4 rounded border-gray-300 accent-black"
-            />
-            <span className="text-sm text-gray-600">Remember me</span>
-          </label>
 
           {/* Submit */}
           <Button type="submit" fullWidth isLoading={isLoading}>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button, Input } from "@/components";
+import { createClient } from "@/utils/supabase/client";
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const supabase = createClient();
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState("");
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isSessionReady, setIsSessionReady] = useState(false);
+
+  useEffect(() => {
+    // Supabase sends the recovery token in the URL hash.
+    // The browser client automatically picks it up and establishes a session.
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (event) => {
+        if (event === "PASSWORD_RECOVERY") {
+          setIsSessionReady(true);
+        }
+      }
+    );
+
+    // Also check if a session already exists (e.g. page refresh after token exchange)
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) {
+        setIsSessionReady(true);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [supabase.auth]);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setApiError("");
+
+    if (password.length < 8) {
+      setApiError("Password must be at least 8 characters long.");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setApiError("Passwords do not match.");
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const { error } = await supabase.auth.updateUser({ password });
+
+      if (error) {
+        setApiError(error.message);
+        setIsLoading(false);
+        return;
+      }
+
+      await supabase.auth.signOut();
+      setIsSubmitted(true);
+    } catch (error) {
+      console.error("Reset password error:", error);
+      setApiError("An unexpected error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-6">
+      <div className="w-full max-w-[420px] animate-slide-up rounded-2xl bg-white p-10 shadow-lg">
+        {/* Brand Header */}
+        <div className="mb-8 text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-black">
+            PrimeTime
+          </h1>
+          <p className="mt-2 text-sm text-gray-500">
+            Prepare. Prime. Perform.
+          </p>
+        </div>
+
+        {isSubmitted ? (
+          /* Success State */
+          <div className="flex flex-col gap-5">
+            <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-center">
+              <p className="text-sm font-medium text-green-800">
+                Password reset successful
+              </p>
+              <p className="mt-1 text-sm text-green-600">
+                Your password has been updated. You can now log in with your new
+                password.
+              </p>
+            </div>
+
+            <Button fullWidth onClick={() => router.push("/login")}>
+              Go to Login
+            </Button>
+          </div>
+        ) : !isSessionReady ? (
+          /* Waiting for session / invalid link */
+          <div className="flex flex-col gap-5">
+            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-center">
+              <p className="text-sm font-medium text-red-800">
+                Invalid or expired reset link
+              </p>
+              <p className="mt-1 text-sm text-red-600">
+                Please request a new password reset link.
+              </p>
+            </div>
+
+            <Link
+              href="/forgot-password"
+              className="block text-center text-sm text-gray-600 transition-colors hover:text-black"
+            >
+              Request new reset link
+            </Link>
+          </div>
+        ) : (
+          /* Reset Password Form */
+          <>
+            <p className="mb-6 text-center text-sm text-gray-500">
+              Enter your new password below.
+            </p>
+
+            <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+              {/* API Error Message */}
+              {apiError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+                  {apiError}
+                </div>
+              )}
+
+              {/* New Password */}
+              <Input
+                label="New Password"
+                type="password"
+                placeholder="••••••••"
+                required
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+
+              {/* Confirm Password */}
+              <Input
+                label="Confirm Password"
+                type="password"
+                placeholder="••••••••"
+                required
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+              />
+
+              {/* Submit */}
+              <Button type="submit" fullWidth isLoading={isLoading}>
+                Reset Password
+              </Button>
+
+              {/* Back to Login */}
+              <Link
+                href="/login"
+                className="block text-center text-sm text-gray-600 transition-colors hover:text-black"
+              >
+                Back to login
+              </Link>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,40 @@
+import { createClient } from '@/utils/supabase/server'
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  try {
+    const { email } = await request.json()
+
+    if (!email) {
+      return NextResponse.json(
+        { error: 'Email is required' },
+        { status: 400 }
+      )
+    }
+
+    const supabase = await createClient()
+
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${new URL(request.url).origin}/reset-password`,
+    })
+
+    if (error) {
+      console.error('Forgot password error:', error)
+      return NextResponse.json(
+        { error: error.message },
+        { status: 400 }
+      )
+    }
+
+    return NextResponse.json(
+      { message: 'Password reset email sent' },
+      { status: 200 }
+    )
+  } catch (error) {
+    console.error('Forgot password error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,16 +26,16 @@ export async function middleware(request: NextRequest) {
     }
   )
 
-  // Get the session
+  // Verify the user with the Supabase Auth server
   const {
-    data: { session },
-  } = await supabase.auth.getSession()
+    data: { user },
+  } = await supabase.auth.getUser()
 
   const pathname = request.nextUrl.pathname
 
   // Protect dashboard routes
   if (pathname.startsWith('/teacher') || pathname.startsWith('/student')) {
-    if (!session) {
+    if (!user) {
       // Not authenticated, redirect to login
       const redirectUrl = new URL('/login', request.url)
       return NextResponse.redirect(redirectUrl)
@@ -46,7 +46,7 @@ export async function middleware(request: NextRequest) {
     const { data: userData } = await supabase
       .from('users')
       .select('role')
-      .eq('id', session.user.id)
+      .eq('id', user.id)
       .single()
 
     if (userData) {
@@ -62,12 +62,12 @@ export async function middleware(request: NextRequest) {
   }
 
   // Redirect authenticated users away from auth pages and root
-  if ((pathname === '/' || pathname === '/login' || pathname === '/signup') && session) {
+  if ((pathname === '/' || pathname === '/login' || pathname === '/signup' || pathname === '/forgot-password') && user) {
     // Get user role to redirect to appropriate dashboard
     const { data: userData } = await supabase
       .from('users')
       .select('role')
-      .eq('id', session.user.id)
+      .eq('id', user.id)
       .single()
 
     if (userData) {


### PR DESCRIPTION
- Added forgot password page that takes only an email that triggers a password reset email
- Added reset password page where users land after clicking aforementioned link, here users enter their new password which still contains same validation
- Added new API route for forget password that takes an email and calls supabase resetPasswordForEmail function, redirects back to /reset-password
- Added /forgot-password to auth pages that redirect logged in users to dashboard
- Replaced getSession() with getUser() in middleware (prior setup was potentially unsafe)
- Removed remember me checkbox from login page, session management is best handled solely through Supabase