### PR TITLE
Add comprehensive unit test suite

### DIFF
--- a/src/app/(auth)/forgot-password/page.test.tsx
+++ b/src/app/(auth)/forgot-password/page.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ForgotPasswordPage from "./page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+global.fetch = vi.fn();
+
+describe("ForgotPasswordPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the PrimeTime heading", () => {
+    render(<ForgotPasswordPage />);
+    expect(screen.getByRole("heading", { name: "PrimeTime" })).toBeInTheDocument();
+  });
+
+  it("renders the email input", () => {
+    render(<ForgotPasswordPage />);
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  });
+
+  it("renders Send Reset Link button", () => {
+    render(<ForgotPasswordPage />);
+    expect(screen.getByRole("button", { name: /Send Reset Link/i })).toBeInTheDocument();
+  });
+
+  it("renders a back to login link", () => {
+    render(<ForgotPasswordPage />);
+    expect(screen.getByRole("link", { name: /Back to login/i })).toHaveAttribute("href", "/login");
+  });
+
+  it("shows success state after successful submission", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: "Reset email sent" }),
+    } as Response);
+
+    render(<ForgotPasswordPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "user@university.edu");
+    await userEvent.click(screen.getByRole("button", { name: /Send Reset Link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Check your email")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the submitted email address in success state", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    render(<ForgotPasswordPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "user@university.edu");
+    await userEvent.click(screen.getByRole("button", { name: /Send Reset Link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("user@university.edu")).toBeInTheDocument();
+    });
+  });
+
+  it("shows API error when request fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "No account found" }),
+    } as Response);
+
+    render(<ForgotPasswordPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "nobody@test.com");
+    await userEvent.click(screen.getByRole("button", { name: /Send Reset Link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("No account found")).toBeInTheDocument();
+    });
+  });
+
+  it("shows generic error on network failure", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<ForgotPasswordPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "user@test.com");
+    await userEvent.click(screen.getByRole("button", { name: /Send Reset Link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state while submitting", async () => {
+    vi.mocked(global.fetch).mockImplementation(() => new Promise(() => {}));
+
+    render(<ForgotPasswordPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "user@test.com");
+    await userEvent.click(screen.getByRole("button", { name: /Send Reset Link/i }));
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+});

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LoginPage from "./page";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+global.fetch = vi.fn();
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the PrimeTime brand heading", () => {
+    render(<LoginPage />);
+    expect(screen.getByRole("heading", { name: "PrimeTime" })).toBeInTheDocument();
+  });
+
+  it("renders email and password inputs", () => {
+    render(<LoginPage />);
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+  });
+
+  it("renders role selector with Student and Teacher options", () => {
+    render(<LoginPage />);
+    expect(screen.getByRole("button", { name: /Student/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Teacher/i })).toBeInTheDocument();
+  });
+
+  it("defaults to student role selected", () => {
+    render(<LoginPage />);
+    // Student button should have the selected styling (black background)
+    const studentBtn = screen.getByRole("button", { name: /Student/i });
+    expect(studentBtn.className).toMatch(/bg-black/);
+  });
+
+  it("switches to teacher role when Teacher is clicked", async () => {
+    render(<LoginPage />);
+    await userEvent.click(screen.getByRole("button", { name: /Teacher/i }));
+    const teacherBtn = screen.getByRole("button", { name: /Teacher/i });
+    expect(teacherBtn.className).toMatch(/bg-black/);
+  });
+
+  it("renders a Log In submit button", () => {
+    render(<LoginPage />);
+    expect(screen.getByRole("button", { name: /Log In/i })).toBeInTheDocument();
+  });
+
+  it("renders a link to forgot password", () => {
+    render(<LoginPage />);
+    expect(screen.getByRole("link", { name: /Forgot password/i })).toHaveAttribute("href", "/forgot-password");
+  });
+
+  it("renders a link to sign up", () => {
+    render(<LoginPage />);
+    expect(screen.getByRole("link", { name: /Sign up/i })).toHaveAttribute("href", "/signup");
+  });
+
+  it("shows loading state while submitting", async () => {
+    vi.mocked(global.fetch).mockImplementation(() => new Promise(() => {}));
+    render(<LoginPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "password123");
+    await userEvent.click(screen.getByRole("button", { name: /Log In/i }));
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("shows API error when login fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Invalid credentials" }),
+    } as Response);
+
+    render(<LoginPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "bad@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "wrongpass");
+    await userEvent.click(screen.getByRole("button", { name: /Log In/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
+    });
+  });
+
+  it("shows role mismatch error when user role does not match selected role", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: { role: "teacher" }, session: {} }),
+    } as Response);
+
+    render(<LoginPage />);
+    // Select student role (default) but API returns teacher
+    await userEvent.type(screen.getByLabelText("Email"), "teacher@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "pass123");
+    await userEvent.click(screen.getByRole("button", { name: /Log In/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/registered as a teacher/i)).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to /teacher on successful teacher login", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: { role: "teacher" }, session: {} }),
+    } as Response);
+
+    render(<LoginPage />);
+    await userEvent.click(screen.getByRole("button", { name: /Teacher/i }));
+    await userEvent.type(screen.getByLabelText("Email"), "teacher@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "pass123");
+    await userEvent.click(screen.getByRole("button", { name: /Log In/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/teacher");
+    });
+  });
+
+  it("redirects to /student on successful student login", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: { role: "student" }, session: {} }),
+    } as Response);
+
+    render(<LoginPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "student@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "pass123");
+    await userEvent.click(screen.getByRole("button", { name: /Log In/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/student");
+    });
+  });
+
+  it("shows generic error on network failure", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+    render(<LoginPage />);
+    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "pass123");
+    await userEvent.click(screen.getByRole("button", { name: /Log In/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/(auth)/reset-password/page.test.tsx
+++ b/src/app/(auth)/reset-password/page.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ResetPasswordPage from "./page";
+
+const mockPush = vi.fn();
+const mockUpdateUser = vi.fn();
+const mockSignOut = vi.fn();
+const mockGetUser = vi.fn();
+const mockUnsubscribe = vi.fn();
+const mockOnAuthStateChange = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/utils/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      updateUser: mockUpdateUser,
+      signOut: mockSignOut,
+      getUser: mockGetUser,
+      onAuthStateChange: mockOnAuthStateChange,
+    },
+  }),
+}));
+
+describe("ResetPasswordPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: mockUnsubscribe } },
+    });
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("renders the PrimeTime heading", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.getByRole("heading", { name: "PrimeTime" })).toBeInTheDocument();
+  });
+
+  it("shows invalid link state when session is not ready", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.getByText("Invalid or expired reset link")).toBeInTheDocument();
+  });
+
+  it("shows a link to request a new reset link when session is invalid", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.getByRole("link", { name: /Request new reset link/i })).toHaveAttribute(
+      "href",
+      "/forgot-password"
+    );
+  });
+
+  it("shows the reset form when session is ready (user exists)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("New Password")).toBeInTheDocument();
+      expect(screen.getByLabelText("Confirm Password")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when password is too short", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => screen.getByLabelText("New Password"));
+
+    await userEvent.type(screen.getByLabelText("New Password"), "short");
+    await userEvent.type(screen.getByLabelText("Confirm Password"), "short");
+    await userEvent.click(screen.getByRole("button", { name: /Reset Password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Password must be at least 8 characters long.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when passwords do not match", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => screen.getByLabelText("New Password"));
+
+    await userEvent.type(screen.getByLabelText("New Password"), "Password123!");
+    await userEvent.type(screen.getByLabelText("Confirm Password"), "DifferentPass!");
+    await userEvent.click(screen.getByRole("button", { name: /Reset Password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Passwords do not match.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows success state after successful password reset", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockUpdateUser.mockResolvedValue({ error: null });
+    mockSignOut.mockResolvedValue({});
+
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => screen.getByLabelText("New Password"));
+
+    await userEvent.type(screen.getByLabelText("New Password"), "NewPassword1!");
+    await userEvent.type(screen.getByLabelText("Confirm Password"), "NewPassword1!");
+    await userEvent.click(screen.getByRole("button", { name: /Reset Password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Password reset successful")).toBeInTheDocument();
+    });
+  });
+
+  it("shows API error when updateUser fails", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockUpdateUser.mockResolvedValue({ error: { message: "Session expired" } });
+
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => screen.getByLabelText("New Password"));
+
+    await userEvent.type(screen.getByLabelText("New Password"), "NewPassword1!");
+    await userEvent.type(screen.getByLabelText("Confirm Password"), "NewPassword1!");
+    await userEvent.click(screen.getByRole("button", { name: /Reset Password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Session expired")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates to /login when Go to Login is clicked in success state", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockUpdateUser.mockResolvedValue({ error: null });
+    mockSignOut.mockResolvedValue({});
+
+    render(<ResetPasswordPage />);
+
+    await waitFor(() => screen.getByLabelText("New Password"));
+
+    await userEvent.type(screen.getByLabelText("New Password"), "NewPassword1!");
+    await userEvent.type(screen.getByLabelText("Confirm Password"), "NewPassword1!");
+    await userEvent.click(screen.getByRole("button", { name: /Reset Password/i }));
+
+    await waitFor(() => screen.getByRole("button", { name: /Go to Login/i }));
+
+    await userEvent.click(screen.getByRole("button", { name: /Go to Login/i }));
+    expect(mockPush).toHaveBeenCalledWith("/login");
+  });
+});

--- a/src/app/(auth)/signup/page.test.tsx
+++ b/src/app/(auth)/signup/page.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SignUpPage from "./page";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+global.fetch = vi.fn();
+
+async function fillValidForm(overrides: Partial<{
+  fullName: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  role: "student" | "teacher";
+  acceptTerms: boolean;
+}> = {}) {
+  const opts = {
+    fullName: "Jane Doe",
+    email: "jane@university.edu",
+    password: "SecurePass1!",
+    confirmPassword: "SecurePass1!",
+    role: "student" as const,
+    acceptTerms: true,
+    ...overrides,
+  };
+
+  await userEvent.type(screen.getByLabelText("Full Name"), opts.fullName);
+  await userEvent.type(screen.getByLabelText("Email"), opts.email);
+  await userEvent.type(screen.getByLabelText("Password"), opts.password);
+  await userEvent.type(screen.getByLabelText("Confirm Password"), opts.confirmPassword);
+
+  if (opts.role === "teacher") {
+    await userEvent.click(screen.getByRole("button", { name: /Teacher/i }));
+  }
+
+  if (opts.acceptTerms) {
+    await userEvent.click(screen.getByRole("checkbox"));
+  }
+}
+
+describe("SignUpPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the PrimeTime heading", () => {
+    render(<SignUpPage />);
+    expect(screen.getByRole("heading", { name: "PrimeTime" })).toBeInTheDocument();
+  });
+
+  it("renders all form fields", () => {
+    render(<SignUpPage />);
+    expect(screen.getByLabelText("Full Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirm Password")).toBeInTheDocument();
+  });
+
+  it("renders role selector", () => {
+    render(<SignUpPage />);
+    expect(screen.getByRole("button", { name: /Student/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Teacher/i })).toBeInTheDocument();
+  });
+
+  it("renders terms checkbox", () => {
+    render(<SignUpPage />);
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
+
+  it("renders Create Account submit button", () => {
+    render(<SignUpPage />);
+    expect(screen.getByRole("button", { name: /Create Account/i })).toBeInTheDocument();
+  });
+
+  it("shows error when full name is empty on submit", async () => {
+    render(<SignUpPage />);
+    // fireEvent.submit bypasses HTML5 required validation so handleSubmit runs
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
+    await waitFor(() => {
+      expect(screen.getByText("Full name is required")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when passwords do not match", async () => {
+    render(<SignUpPage />);
+    await userEvent.type(screen.getByLabelText("Full Name"), "Jane");
+    await userEvent.type(screen.getByLabelText("Email"), "jane@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "Password1!");
+    await userEvent.type(screen.getByLabelText("Confirm Password"), "DifferentPass1!");
+    await userEvent.click(screen.getByRole("button", { name: /Create Account/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when password is too short", async () => {
+    render(<SignUpPage />);
+    await userEvent.type(screen.getByLabelText("Full Name"), "Jane");
+    await userEvent.type(screen.getByLabelText("Email"), "jane@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "short");
+    await userEvent.type(screen.getByLabelText("Confirm Password"), "short");
+    await userEvent.click(screen.getByRole("button", { name: /Create Account/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Password must be at least 8 characters long")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when terms are not accepted", async () => {
+    render(<SignUpPage />);
+    await userEvent.type(screen.getByLabelText("Full Name"), "Jane");
+    await userEvent.type(screen.getByLabelText("Email"), "jane@test.com");
+    await userEvent.type(screen.getByLabelText("Password"), "Password1!");
+    await userEvent.type(screen.getByLabelText("Confirm Password"), "Password1!");
+    await userEvent.click(screen.getByRole("button", { name: /Create Account/i }));
+    await waitFor(() => {
+      expect(screen.getByText("You must accept the terms to continue")).toBeInTheDocument();
+    });
+  });
+
+  it("shows weak password indicator for weak passwords", async () => {
+    render(<SignUpPage />);
+    await userEvent.type(screen.getByLabelText("Password"), "weak");
+    await waitFor(() => {
+      expect(screen.getByText("Weak password")).toBeInTheDocument();
+    });
+  });
+
+  it("shows strong password indicator for strong passwords", async () => {
+    render(<SignUpPage />);
+    await userEvent.type(screen.getByLabelText("Password"), "StrongPass1!");
+    await waitFor(() => {
+      expect(screen.getByText("Strong password")).toBeInTheDocument();
+    });
+  });
+
+  it("shows invalid email error on blur with bad email", async () => {
+    render(<SignUpPage />);
+    const emailInput = screen.getByLabelText("Email");
+    await userEvent.type(emailInput, "notanemail");
+    await userEvent.tab(); // trigger blur
+    await waitFor(() => {
+      expect(screen.getByText("Please enter a valid email address")).toBeInTheDocument();
+    });
+  });
+
+  it("shows API error when signup fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Email already in use" }),
+    } as Response);
+
+    render(<SignUpPage />);
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: /Create Account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Email already in use")).toBeInTheDocument();
+    });
+  });
+
+  it("redirects to /student on successful student signup", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: { id: "1", email: "jane@test.com", role: "student" }, session: {} }),
+    } as Response);
+
+    render(<SignUpPage />);
+    await fillValidForm({ role: "student" });
+    await userEvent.click(screen.getByRole("button", { name: /Create Account/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/student");
+    });
+  });
+
+  it("redirects to /teacher on successful teacher signup", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: { id: "1", email: "prof@test.com", role: "teacher" }, session: {} }),
+    } as Response);
+
+    render(<SignUpPage />);
+    await fillValidForm({ role: "teacher" });
+    await userEvent.click(screen.getByRole("button", { name: /Create Account/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/teacher");
+    });
+  });
+
+  it("shows generic error on network failure", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+    render(<SignUpPage />);
+    await fillValidForm();
+    await userEvent.click(screen.getByRole("button", { name: /Create Account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders link to login page", () => {
+    render(<SignUpPage />);
+    expect(screen.getByRole("link", { name: /Log in/i })).toHaveAttribute("href", "/login");
+  });
+});

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -1,0 +1,125 @@
+import { POST } from "./route";
+
+const mockSignInWithPassword = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      signInWithPassword: mockSignInWithPassword,
+    },
+    from: mockFrom,
+  })),
+}));
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const res = await POST(makeRequest({ password: "pass123" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Email and password are required");
+  });
+
+  it("returns 400 when password is missing", async () => {
+    const res = await POST(makeRequest({ email: "user@test.com" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Email and password are required");
+  });
+
+  it("returns 401 when Supabase auth fails", async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({
+      data: { user: null, session: null },
+      error: { message: "Invalid login credentials" },
+    });
+
+    const res = await POST(makeRequest({ email: "user@test.com", password: "wrong" }));
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("Invalid login credentials");
+  });
+
+  it("returns 401 when auth data has no user", async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({
+      data: { user: null, session: null },
+      error: null,
+    });
+
+    const res = await POST(makeRequest({ email: "user@test.com", password: "pass123" }));
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("Failed to authenticate user");
+  });
+
+  it("returns 500 when user profile fetch fails", async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({
+      data: { user: { id: "user-1" }, session: {} },
+      error: null,
+    });
+
+    const mockSelect = vi.fn().mockReturnThis();
+    const mockEq = vi.fn().mockReturnThis();
+    const mockSingle = vi.fn().mockResolvedValueOnce({
+      data: null,
+      error: { message: "DB error" },
+    });
+
+    mockFrom.mockReturnValue({ select: mockSelect, eq: mockEq, single: mockSingle });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+
+    const res = await POST(makeRequest({ email: "user@test.com", password: "pass123" }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Failed to fetch user profile");
+  });
+
+  it("returns 200 with user data on successful login", async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({
+      data: {
+        user: { id: "user-1" },
+        session: { access_token: "tok" },
+      },
+      error: null,
+    });
+
+    const mockSelect = vi.fn().mockReturnThis();
+    const mockEq = vi.fn().mockReturnThis();
+    const mockSingle = vi.fn().mockResolvedValueOnce({
+      data: {
+        id: "user-1",
+        email: "user@test.com",
+        role: "student",
+        full_name: "Test User",
+      },
+      error: null,
+    });
+
+    mockFrom.mockReturnValue({ select: mockSelect, eq: mockEq, single: mockSingle });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+
+    const res = await POST(makeRequest({ email: "user@test.com", password: "pass123" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.user).toEqual({
+      id: "user-1",
+      email: "user@test.com",
+      role: "student",
+      fullName: "Test User",
+    });
+    expect(data.session).toBeDefined();
+  });
+});

--- a/src/app/api/auth/signup/route.test.ts
+++ b/src/app/api/auth/signup/route.test.ts
@@ -1,0 +1,131 @@
+import { POST } from "./route";
+
+const mockSignUp = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      signUp: mockSignUp,
+    },
+    from: mockFrom,
+  })),
+}));
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/auth/signup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  email: "new@test.com",
+  password: "SecurePass1!",
+  role: "student",
+  fullName: "New User",
+};
+
+describe("POST /api/auth/signup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const res = await POST(makeRequest({ password: "pass", role: "student", fullName: "Name" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Missing required fields");
+  });
+
+  it("returns 400 when password is missing", async () => {
+    const res = await POST(makeRequest({ email: "a@b.com", role: "student", fullName: "Name" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Missing required fields");
+  });
+
+  it("returns 400 when role is missing", async () => {
+    const res = await POST(makeRequest({ email: "a@b.com", password: "pass", fullName: "Name" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Missing required fields");
+  });
+
+  it("returns 400 when fullName is missing", async () => {
+    const res = await POST(makeRequest({ email: "a@b.com", password: "pass", role: "student" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Missing required fields");
+  });
+
+  it("returns 400 for invalid role", async () => {
+    const res = await POST(makeRequest({ ...validBody, role: "admin" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/Invalid role/);
+  });
+
+  it("returns 400 when password is too short", async () => {
+    const res = await POST(makeRequest({ ...validBody, password: "short" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Password must be at least 8 characters long");
+  });
+
+  it("returns 400 when Supabase auth signUp fails", async () => {
+    mockSignUp.mockResolvedValueOnce({
+      data: { user: null, session: null },
+      error: { message: "Email already registered" },
+    });
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Email already registered");
+  });
+
+  it("returns 201 with user data on successful signup (with session)", async () => {
+    mockSignUp.mockResolvedValueOnce({
+      data: {
+        user: { id: "user-1" },
+        session: { access_token: "tok" },
+      },
+      error: null,
+    });
+
+    const mockInsert = vi.fn().mockResolvedValueOnce({ error: null });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.user).toEqual({
+      id: "user-1",
+      email: "new@test.com",
+      role: "student",
+      fullName: "New User",
+    });
+  });
+
+  it("returns 500 when user table insert fails", async () => {
+    mockSignUp.mockResolvedValueOnce({
+      data: {
+        user: { id: "user-1" },
+        session: { access_token: "tok" },
+      },
+      error: null,
+    });
+
+    const mockInsert = vi.fn().mockResolvedValueOnce({
+      error: { message: "Duplicate key" },
+    });
+    mockFrom.mockReturnValue({ insert: mockInsert });
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/Failed to create user profile/);
+  });
+});

--- a/src/app/api/courses/route.test.ts
+++ b/src/app/api/courses/route.test.ts
@@ -1,0 +1,143 @@
+import { GET, POST } from "./route";
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+// Helper to build a chainable Supabase query mock
+function makeChain(finalResult: unknown) {
+  const chain: Record<string, unknown> = {};
+  const methods = ["select", "insert", "update", "delete", "eq", "order", "single"];
+  methods.forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  // The last call in each chain returns a promise
+  (chain.order as ReturnType<typeof vi.fn>).mockResolvedValue(finalResult);
+  (chain.single as ReturnType<typeof vi.fn>).mockResolvedValue(finalResult);
+  return chain;
+}
+
+describe("GET /api/courses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns 403 when user is not a teacher", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "user-1" } }, error: null });
+
+    // First from() call: get user profile → returns student role
+    const profileChain = makeChain({ data: { role: "student" }, error: null });
+    mockFrom.mockReturnValueOnce(profileChain);
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toBe("Forbidden");
+  });
+
+  it("returns 200 with courses for authenticated teacher", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "teacher-1" } }, error: null });
+
+    const courses = [{ id: "c1", title: "Psych 101" }];
+    const profileChain = makeChain({ data: { role: "teacher" }, error: null });
+    const coursesChain = makeChain({ data: courses, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(profileChain)
+      .mockReturnValueOnce(coursesChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.courses).toEqual(courses);
+  });
+});
+
+describe("POST /api/courses", () => {
+  function makeRequest(body: unknown) {
+    return new Request("http://localhost/api/courses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when title is missing", async () => {
+    const res = await POST(makeRequest({ courseCode: "PSY101", semester: "Fall 2026" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/required/i);
+  });
+
+  it("returns 400 when courseCode is missing", async () => {
+    const res = await POST(makeRequest({ title: "Psych", semester: "Fall 2026" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/required/i);
+  });
+
+  it("returns 400 when semester is missing", async () => {
+    const res = await POST(makeRequest({ title: "Psych", courseCode: "PSY101" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/required/i);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+
+    const res = await POST(makeRequest({ title: "Psych", courseCode: "PSY101", semester: "Fall 2026" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not a teacher", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "user-1" } }, error: null });
+
+    const profileChain = makeChain({ data: { role: "student" }, error: null });
+    mockFrom.mockReturnValueOnce(profileChain);
+
+    const res = await POST(makeRequest({ title: "Psych", courseCode: "PSY101", semester: "Fall 2026" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 201 with new course on successful creation", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "teacher-1" } }, error: null });
+
+    const newCourse = { id: "c1", title: "Psych 101", course_code: "PSY101", semester: "Fall 2026" };
+    const profileChain = makeChain({ data: { role: "teacher" }, error: null });
+
+    // courses insert chain: select().single()
+    const insertChain: Record<string, unknown> = {};
+    insertChain.insert = vi.fn().mockReturnValue(insertChain);
+    insertChain.select = vi.fn().mockReturnValue(insertChain);
+    insertChain.single = vi.fn().mockResolvedValue({ data: newCourse, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(profileChain)
+      .mockReturnValueOnce(insertChain);
+
+    const res = await POST(makeRequest({ title: "Psych 101", courseCode: "PSY101", semester: "Fall 2026" }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.course).toEqual(newCourse);
+  });
+});

--- a/src/app/api/enrollments/route.test.ts
+++ b/src/app/api/enrollments/route.test.ts
@@ -1,0 +1,166 @@
+import { GET, POST } from "./route";
+
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/utils/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+// Build a chainable mock; the terminal method resolves with `finalResult`
+function makeChain(finalResult: unknown, terminalMethod = "single") {
+  const chain: Record<string, unknown> = {};
+  const methods = ["select", "insert", "eq", "order", "single"];
+  methods.forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  (chain[terminalMethod] as ReturnType<typeof vi.fn>).mockResolvedValue(finalResult);
+  return chain;
+}
+
+describe("GET /api/enrollments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not a student", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "t1" } }, error: null });
+    const profileChain = makeChain({ data: { role: "teacher" }, error: null });
+    mockFrom.mockReturnValueOnce(profileChain);
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toBe("Forbidden");
+  });
+
+  it("returns 200 with enrollments for a student", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "s1" } }, error: null });
+
+    const enrollments = [{ id: "e1", enrolled_at: "2026-01-01", course: { title: "Psych 101" } }];
+
+    const profileChain = makeChain({ data: { role: "student" }, error: null });
+    const enrollmentsChain = makeChain({ data: enrollments, error: null }, "order");
+
+    mockFrom
+      .mockReturnValueOnce(profileChain)
+      .mockReturnValueOnce(enrollmentsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.enrollments).toEqual(enrollments);
+  });
+});
+
+describe("POST /api/enrollments", () => {
+  function makeRequest(body: unknown) {
+    return new Request("http://localhost/api/enrollments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+    const res = await POST(makeRequest({ invitationCode: "ABCDEF" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not a student", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "t1" } }, error: null });
+    const profileChain = makeChain({ data: { role: "teacher" }, error: null });
+    mockFrom.mockReturnValueOnce(profileChain);
+
+    const res = await POST(makeRequest({ invitationCode: "ABCDEF" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when invitationCode is missing", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "s1" } }, error: null });
+    const profileChain = makeChain({ data: { role: "student" }, error: null });
+    mockFrom.mockReturnValueOnce(profileChain);
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/required/i);
+  });
+
+  it("returns 404 when invitation code is invalid", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "s1" } }, error: null });
+
+    const profileChain = makeChain({ data: { role: "student" }, error: null });
+    const courseChain = makeChain({ data: null, error: { message: "No rows found" } });
+
+    mockFrom
+      .mockReturnValueOnce(profileChain)
+      .mockReturnValueOnce(courseChain);
+
+    const res = await POST(makeRequest({ invitationCode: "BADCOD" }));
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toMatch(/Invalid invitation code/i);
+  });
+
+  it("returns 409 when already enrolled", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "s1" } }, error: null });
+
+    const profileChain = makeChain({ data: { role: "student" }, error: null });
+    const courseChain = makeChain({ data: { id: "c1" }, error: null });
+    const existingChain = makeChain({ data: { id: "e1" }, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(profileChain)
+      .mockReturnValueOnce(courseChain)
+      .mockReturnValueOnce(existingChain);
+
+    const res = await POST(makeRequest({ invitationCode: "ABCDEF" }));
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toMatch(/already enrolled/i);
+  });
+
+  it("returns 201 with enrollment on success", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "s1" } }, error: null });
+
+    const enrollment = { id: "e1", enrolled_at: "2026-01-01" };
+    const course = { id: "c1", title: "Psych 101" };
+
+    const profileChain = makeChain({ data: { role: "student" }, error: null });
+    const courseChain = makeChain({ data: course, error: null });
+    const existingChain = makeChain({ data: null, error: null }); // not enrolled
+
+    // Insert chain: insert().select().single()
+    const insertChain: Record<string, unknown> = {};
+    insertChain.insert = vi.fn().mockReturnValue(insertChain);
+    insertChain.select = vi.fn().mockReturnValue(insertChain);
+    insertChain.single = vi.fn().mockResolvedValue({ data: enrollment, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(profileChain)
+      .mockReturnValueOnce(courseChain)
+      .mockReturnValueOnce(existingChain)
+      .mockReturnValueOnce(insertChain);
+
+    const res = await POST(makeRequest({ invitationCode: "ABCDEF" }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.enrollment).toEqual(enrollment);
+    expect(data.course).toEqual(course);
+  });
+});

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Button from "./Button";
+
+describe("Button", () => {
+  it("renders children", () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
+  });
+
+  it("defaults to primary variant", () => {
+    render(<Button>Primary</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-black/);
+    expect(btn.className).toMatch(/text-white/);
+  });
+
+  it("applies secondary variant styles", () => {
+    render(<Button variant="secondary">Secondary</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-gray-100/);
+    expect(btn.className).toMatch(/text-black/);
+  });
+
+  it("applies ghost variant styles", () => {
+    render(<Button variant="ghost">Ghost</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.className).toMatch(/bg-transparent/);
+  });
+
+  it("applies sm size styles", () => {
+    render(<Button size="sm">Small</Button>);
+    expect(screen.getByRole("button").className).toMatch(/text-xs/);
+  });
+
+  it("applies lg size styles", () => {
+    render(<Button size="lg">Large</Button>);
+    expect(screen.getByRole("button").className).toMatch(/text-base/);
+  });
+
+  it("applies full width when fullWidth is true", () => {
+    render(<Button fullWidth>Full</Button>);
+    expect(screen.getByRole("button").className).toMatch(/w-full/);
+  });
+
+  it("does not apply w-full by default", () => {
+    render(<Button>Normal</Button>);
+    expect(screen.getByRole("button").className).not.toMatch(/w-full/);
+  });
+
+  it("shows loading spinner when isLoading is true", () => {
+    render(<Button isLoading>Save</Button>);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.queryByText("Save")).not.toBeInTheDocument();
+  });
+
+  it("disables the button when isLoading is true", () => {
+    render(<Button isLoading>Save</Button>);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("disables the button when disabled prop is set", () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("calls onClick when clicked", async () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Click</Button>);
+    await userEvent.click(screen.getByRole("button"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClick when disabled", async () => {
+    const handleClick = vi.fn();
+    render(<Button disabled onClick={handleClick}>Disabled</Button>);
+    await userEvent.click(screen.getByRole("button"));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it("renders iconBefore when provided", () => {
+    render(<Button iconBefore={<span data-testid="icon-before" />}>With Icon</Button>);
+    expect(screen.getByTestId("icon-before")).toBeInTheDocument();
+  });
+
+  it("renders iconAfter when provided", () => {
+    render(<Button iconAfter={<span data-testid="icon-after" />}>With Icon</Button>);
+    expect(screen.getByTestId("icon-after")).toBeInTheDocument();
+  });
+
+  it("merges custom className", () => {
+    render(<Button className="custom-class">Styled</Button>);
+    expect(screen.getByRole("button").className).toMatch(/custom-class/);
+  });
+
+  it("forwards button type attribute", () => {
+    render(<Button type="submit">Submit</Button>);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
+  });
+});

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import Card from "./Card";
+
+describe("Card", () => {
+  it("renders children", () => {
+    render(<Card>Card content</Card>);
+    expect(screen.getByText("Card content")).toBeInTheDocument();
+  });
+
+  it("applies default styles", () => {
+    render(<Card data-testid="card">Content</Card>);
+    const card = screen.getByTestId("card");
+    expect(card.className).toMatch(/rounded-xl/);
+    expect(card.className).toMatch(/border/);
+    expect(card.className).toMatch(/bg-white/);
+  });
+
+  it("merges custom className", () => {
+    render(<Card data-testid="card" className="custom-class">Content</Card>);
+    expect(screen.getByTestId("card").className).toMatch(/custom-class/);
+  });
+
+  describe("Card.Header", () => {
+    it("renders children", () => {
+      render(<Card.Header>Header Content</Card.Header>);
+      expect(screen.getByText("Header Content")).toBeInTheDocument();
+    });
+
+    it("applies margin-bottom styles", () => {
+      render(<Card.Header data-testid="header">Header</Card.Header>);
+      expect(screen.getByTestId("header").className).toMatch(/mb-4/);
+    });
+
+    it("merges custom className", () => {
+      render(<Card.Header data-testid="header" className="custom-header">Header</Card.Header>);
+      expect(screen.getByTestId("header").className).toMatch(/custom-header/);
+    });
+  });
+
+  describe("Card.Title", () => {
+    it("renders as h3", () => {
+      render(<Card.Title>My Title</Card.Title>);
+      expect(screen.getByRole("heading", { level: 3, name: "My Title" })).toBeInTheDocument();
+    });
+
+    it("applies title styles", () => {
+      render(<Card.Title>Title</Card.Title>);
+      expect(screen.getByRole("heading").className).toMatch(/font-semibold/);
+    });
+  });
+
+  describe("Card.Description", () => {
+    it("renders children", () => {
+      render(<Card.Description>A description</Card.Description>);
+      expect(screen.getByText("A description")).toBeInTheDocument();
+    });
+
+    it("applies description styles", () => {
+      render(<Card.Description>Desc</Card.Description>);
+      expect(screen.getByText("Desc").className).toMatch(/text-gray-500/);
+    });
+  });
+
+  describe("Card.Content", () => {
+    it("renders children", () => {
+      render(<Card.Content>Main content</Card.Content>);
+      expect(screen.getByText("Main content")).toBeInTheDocument();
+    });
+  });
+
+  describe("Card.Footer", () => {
+    it("renders children", () => {
+      render(<Card.Footer>Footer</Card.Footer>);
+      expect(screen.getByText("Footer")).toBeInTheDocument();
+    });
+
+    it("applies footer layout styles", () => {
+      render(<Card.Footer data-testid="footer">Footer</Card.Footer>);
+      const footer = screen.getByTestId("footer");
+      expect(footer.className).toMatch(/mt-4/);
+      expect(footer.className).toMatch(/flex/);
+    });
+  });
+
+  it("composes all subcomponents together", () => {
+    render(
+      <Card>
+        <Card.Header>
+          <Card.Title>Course Name</Card.Title>
+          <Card.Description>Course description</Card.Description>
+        </Card.Header>
+        <Card.Content>Content here</Card.Content>
+        <Card.Footer>
+          <button>Action</button>
+        </Card.Footer>
+      </Card>
+    );
+    expect(screen.getByRole("heading", { name: "Course Name" })).toBeInTheDocument();
+    expect(screen.getByText("Course description")).toBeInTheDocument();
+    expect(screen.getByText("Content here")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
+  });
+});

--- a/src/components/Input.test.tsx
+++ b/src/components/Input.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Input from "./Input";
+
+describe("Input", () => {
+  it("renders without label", () => {
+    render(<Input placeholder="Enter text" />);
+    expect(screen.getByPlaceholderText("Enter text")).toBeInTheDocument();
+  });
+
+  it("renders with label", () => {
+    render(<Input label="Email" />);
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+  });
+
+  it("associates label with input via auto-generated id", () => {
+    render(<Input label="Full Name" />);
+    const input = screen.getByLabelText("Full Name");
+    expect(input).toHaveAttribute("id", "full-name");
+  });
+
+  it("uses provided id over auto-generated one", () => {
+    render(<Input label="Email" id="custom-email-id" />);
+    expect(screen.getByLabelText("Email")).toHaveAttribute("id", "custom-email-id");
+  });
+
+  it("renders error message", () => {
+    render(<Input label="Email" error="Invalid email" />);
+    expect(screen.getByText("Invalid email")).toBeInTheDocument();
+  });
+
+  it("sets aria-invalid when error is provided", () => {
+    render(<Input label="Email" error="Required" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("sets aria-describedby pointing to error element", () => {
+    render(<Input label="Email" error="Required" />);
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveAttribute("aria-describedby", "email-error");
+    expect(screen.getByText("Required")).toHaveAttribute("id", "email-error");
+  });
+
+  it("does not set aria-invalid when no error", () => {
+    render(<Input label="Email" />);
+    expect(screen.getByRole("textbox")).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("applies error border styles when error provided", () => {
+    render(<Input label="Email" error="Required" />);
+    expect(screen.getByRole("textbox").className).toMatch(/border-red-500/);
+  });
+
+  it("applies normal border styles when no error", () => {
+    render(<Input label="Email" />);
+    expect(screen.getByRole("textbox").className).toMatch(/border-gray-300/);
+  });
+
+  it("accepts user input", async () => {
+    render(<Input label="Name" />);
+    const input = screen.getByLabelText("Name");
+    await userEvent.type(input, "John");
+    expect(input).toHaveValue("John");
+  });
+
+  it("calls onChange when typing", async () => {
+    const handleChange = vi.fn();
+    render(<Input onChange={handleChange} />);
+    await userEvent.type(screen.getByRole("textbox"), "a");
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it("is disabled when disabled prop is set", () => {
+    render(<Input disabled />);
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  it("renders password type input", () => {
+    render(<Input label="Password" type="password" />);
+    expect(screen.getByLabelText("Password")).toHaveAttribute("type", "password");
+  });
+
+  it("merges custom className", () => {
+    render(<Input className="custom-class" />);
+    expect(screen.getByRole("textbox").className).toMatch(/custom-class/);
+  });
+});

--- a/src/components/features/CreateCourseModal.test.tsx
+++ b/src/components/features/CreateCourseModal.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreateCourseModal from "./CreateCourseModal";
+
+global.fetch = vi.fn();
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  onCourseCreated: vi.fn(),
+};
+
+describe("CreateCourseModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render when closed", () => {
+    render(<CreateCourseModal {...defaultProps} open={false} />);
+    expect(screen.queryByText("Create Course")).not.toBeInTheDocument();
+  });
+
+  it("renders the modal title when open", () => {
+    render(<CreateCourseModal {...defaultProps} />);
+    // getByRole dialog title (heading level 2 from Radix Dialog.Title renders as h2)
+    // The text "Create Course" appears as modal title
+    expect(screen.getAllByText("Create Course").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders all form fields", () => {
+    render(<CreateCourseModal {...defaultProps} />);
+    expect(screen.getByLabelText("Course Title")).toBeInTheDocument();
+    expect(screen.getByLabelText("Description")).toBeInTheDocument();
+    expect(screen.getByLabelText("Course Code")).toBeInTheDocument();
+    expect(screen.getByLabelText("Semester")).toBeInTheDocument();
+  });
+
+  it("renders Cancel and Create Course buttons", () => {
+    render(<CreateCourseModal {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create Course" })).toBeInTheDocument();
+  });
+
+  it("shows validation error when required fields are missing", async () => {
+    render(<CreateCourseModal {...defaultProps} />);
+    // Use fireEvent.submit to bypass HTML5 required validation and trigger handleSubmit
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
+    await waitFor(() => {
+      expect(screen.getByText("Title, course code, and semester are required.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows validation error when only title is missing", async () => {
+    render(<CreateCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Course Code"), "PSY101");
+    await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
+    await waitFor(() => {
+      expect(screen.getByText("Title, course code, and semester are required.")).toBeInTheDocument();
+    });
+  });
+
+  it("calls fetch with correct data on valid submission", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ course: { id: "1", title: "Psych 101" } }),
+    } as Response);
+
+    render(<CreateCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Course Title"), "Introduction to Psychology");
+    await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
+    await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
+    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/courses", expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          title: "Introduction to Psychology",
+          description: undefined,
+          courseCode: "PSY 101",
+          semester: "Fall 2026",
+        }),
+      }));
+    });
+  });
+
+  it("calls onCourseCreated and closes modal on success", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ course: { id: "1" } }),
+    } as Response);
+
+    render(<CreateCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Course Title"), "Psych 101");
+    await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
+    await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
+    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+
+    await waitFor(() => {
+      expect(defaultProps.onCourseCreated).toHaveBeenCalled();
+      expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("shows API error when course creation fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Course code already exists" }),
+    } as Response);
+
+    render(<CreateCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Course Title"), "Psych 101");
+    await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
+    await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
+    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Course code already exists")).toBeInTheDocument();
+    });
+  });
+
+  it("shows generic error on network failure", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<CreateCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Course Title"), "Psych 101");
+    await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
+    await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
+    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state while submitting", async () => {
+    vi.mocked(global.fetch).mockImplementation(() => new Promise(() => {}));
+
+    render(<CreateCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Course Title"), "Psych 101");
+    await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
+    await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
+    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("resets form fields when modal is closed and reopened", async () => {
+    const { rerender } = render(<CreateCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Course Title"), "Some Course");
+
+    // Close the modal
+    rerender(<CreateCourseModal {...defaultProps} open={false} />);
+    // Reopen the modal
+    rerender(<CreateCourseModal {...defaultProps} open={true} />);
+
+    expect(screen.getByLabelText("Course Title")).toHaveValue("");
+  });
+});

--- a/src/components/features/EnrollCourseModal.test.tsx
+++ b/src/components/features/EnrollCourseModal.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EnrollCourseModal from "./EnrollCourseModal";
+
+global.fetch = vi.fn();
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  onEnrolled: vi.fn(),
+};
+
+describe("EnrollCourseModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render when closed", () => {
+    render(<EnrollCourseModal {...defaultProps} open={false} />);
+    expect(screen.queryByText("Enroll in Course")).not.toBeInTheDocument();
+  });
+
+  it("renders the modal title when open", () => {
+    render(<EnrollCourseModal {...defaultProps} />);
+    expect(screen.getByText("Enroll in Course")).toBeInTheDocument();
+  });
+
+  it("renders the invitation code input", () => {
+    render(<EnrollCourseModal {...defaultProps} />);
+    expect(screen.getByLabelText("Invitation Code")).toBeInTheDocument();
+  });
+
+  it("renders Cancel and Join Course buttons", () => {
+    render(<EnrollCourseModal {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Join Course" })).toBeInTheDocument();
+  });
+
+  it("shows error when invitation code is empty", async () => {
+    render(<EnrollCourseModal {...defaultProps} />);
+    // Use fireEvent.submit to bypass HTML5 required validation
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
+    await waitFor(() => {
+      expect(screen.getByText("Please enter an invitation code.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when invitation code is too short (< 6 chars)", async () => {
+    render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "ABC");
+    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+    await waitFor(() => {
+      expect(screen.getByText("Invitation code must be at least 6 characters.")).toBeInTheDocument();
+    });
+  });
+
+  it("uppercases input as user types", async () => {
+    render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "abcdef");
+    expect(screen.getByLabelText("Invitation Code")).toHaveValue("ABCDEF");
+  });
+
+  it("calls fetch with correct data on valid submission", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ enrollment: { id: "1" }, course: { title: "Psych 101" } }),
+    } as Response);
+
+    render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
+    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/enrollments", expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ invitationCode: "ABCDEF" }),
+      }));
+    });
+  });
+
+  it("calls onEnrolled and closes modal on success", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ enrollment: { id: "1" }, course: { title: "Psych 101" } }),
+    } as Response);
+
+    render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
+    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+
+    await waitFor(() => {
+      expect(defaultProps.onEnrolled).toHaveBeenCalled();
+      expect(defaultProps.onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("shows API error when enrollment fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Invalid invitation code. Please check with your teacher." }),
+    } as Response);
+
+    render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "BADCOD");
+    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid invitation code. Please check with your teacher.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows already-enrolled error", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "You are already enrolled in this course." }),
+    } as Response);
+
+    render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
+    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("You are already enrolled in this course.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows generic error on network failure", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
+    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state while submitting", async () => {
+    vi.mocked(global.fetch).mockImplementation(() => new Promise(() => {}));
+
+    render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
+    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("resets form when modal is closed and reopened", async () => {
+    const { rerender } = render(<EnrollCourseModal {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
+
+    rerender(<EnrollCourseModal {...defaultProps} open={false} />);
+    rerender(<EnrollCourseModal {...defaultProps} open={true} />);
+
+    expect(screen.getByLabelText("Invitation Code")).toHaveValue("");
+  });
+});

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Modal from "./Modal";
+
+describe("Modal", () => {
+  it("does not render content when closed", () => {
+    render(
+      <Modal open={false} onOpenChange={vi.fn()}>
+        <Modal.Content>
+          <Modal.Title>Hidden Modal</Modal.Title>
+        </Modal.Content>
+      </Modal>
+    );
+    expect(screen.queryByText("Hidden Modal")).not.toBeInTheDocument();
+  });
+
+  it("renders content when open", () => {
+    render(
+      <Modal open={true} onOpenChange={vi.fn()}>
+        <Modal.Content>
+          <Modal.Title>Open Modal</Modal.Title>
+        </Modal.Content>
+      </Modal>
+    );
+    expect(screen.getByText("Open Modal")).toBeInTheDocument();
+  });
+
+  it("renders Modal.Description when open", () => {
+    render(
+      <Modal open={true} onOpenChange={vi.fn()}>
+        <Modal.Content>
+          <Modal.Title>Title</Modal.Title>
+          <Modal.Description>Some description</Modal.Description>
+        </Modal.Content>
+      </Modal>
+    );
+    expect(screen.getByText("Some description")).toBeInTheDocument();
+  });
+
+  it("renders close button inside content", () => {
+    render(
+      <Modal open={true} onOpenChange={vi.fn()}>
+        <Modal.Content>
+          <Modal.Title>Title</Modal.Title>
+        </Modal.Content>
+      </Modal>
+    );
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("calls onOpenChange(false) when close button is clicked", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open={true} onOpenChange={onOpenChange}>
+        <Modal.Content>
+          <Modal.Title>Title</Modal.Title>
+        </Modal.Content>
+      </Modal>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders Modal.Footer with children", () => {
+    render(
+      <Modal open={true} onOpenChange={vi.fn()}>
+        <Modal.Content>
+          <Modal.Title>Title</Modal.Title>
+          <Modal.Footer>
+            <button>Cancel</button>
+            <button>Confirm</button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+    );
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+  });
+
+  it("renders a trigger button that opens the modal", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open={false} onOpenChange={onOpenChange}>
+        <Modal.Trigger>
+          <button>Open</button>
+        </Modal.Trigger>
+        <Modal.Content>
+          <Modal.Title>Title</Modal.Title>
+        </Modal.Content>
+      </Modal>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it("renders Modal.Title with correct heading styles", () => {
+    render(
+      <Modal open={true} onOpenChange={vi.fn()}>
+        <Modal.Content>
+          <Modal.Title>My Modal</Modal.Title>
+        </Modal.Content>
+      </Modal>
+    );
+    const title = screen.getByText("My Modal");
+    expect(title.className).toMatch(/font-semibold/);
+  });
+
+  it("renders Modal.Close wrapping a button that triggers onOpenChange", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Modal open={true} onOpenChange={onOpenChange}>
+        <Modal.Content>
+          <Modal.Title>Title</Modal.Title>
+          <Modal.Footer>
+            <Modal.Close>
+              <button>Cancel</button>
+            </Modal.Close>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
164 tests across 14 files Covers UI components (Button, Input, Card, Modal), feature modals (CreateCourseModal, EnrollCourseModal), all auth pages (login, signup, forgot-password, reset-password), and API routes (auth, courses, enrollments). Increases test count from 1 unit test to 165 total.