### PR TITLE
Restyle modals to match brutalist design system

### DIFF
--- a/src/app/(dashboard)/student/page.tsx
+++ b/src/app/(dashboard)/student/page.tsx
@@ -258,6 +258,7 @@ export default function StudentDashboardPage() {
         open={enrollModalOpen}
         onOpenChange={setEnrollModalOpen}
         onEnrolled={fetchEnrollments}
+        isDark={isDark}
       />
     </>
   );

--- a/src/app/(dashboard)/teacher/courses/[id]/page.tsx
+++ b/src/app/(dashboard)/teacher/courses/[id]/page.tsx
@@ -522,8 +522,8 @@ function SessionsTab({ courseId, sessions, isLoading, onRefresh, isDark }: Reado
         }>CREATE SESSION</BrutalistButton>
       </div>
 
-      <CreateSessionModal open={showCreateModal} onOpenChange={setShowCreateModal} courseId={courseId} onCreated={handleSessionCreated} />
-      <AssignSessionModal open={showAssignModal} onOpenChange={setShowAssignModal} courseId={courseId} sessions={sessions} assignedSessionIds={assignedSessionIds} onAssigned={handleAssigned} />
+      <CreateSessionModal open={showCreateModal} onOpenChange={setShowCreateModal} courseId={courseId} onCreated={handleSessionCreated} isDark={isDark} />
+      <AssignSessionModal open={showAssignModal} onOpenChange={setShowAssignModal} courseId={courseId} sessions={sessions} assignedSessionIds={assignedSessionIds} onAssigned={handleAssigned} isDark={isDark} />
 
       {sessions.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">

--- a/src/app/(dashboard)/teacher/page.tsx
+++ b/src/app/(dashboard)/teacher/page.tsx
@@ -149,6 +149,7 @@ export default function TeacherDashboardPage() {
         open={modalOpen}
         onOpenChange={setModalOpen}
         onCourseCreated={fetchCourses}
+        isDark={isDark}
       />
     </div>
   );

--- a/src/components/features/AssignSessionModal.test.tsx
+++ b/src/components/features/AssignSessionModal.test.tsx
@@ -87,7 +87,7 @@ describe("AssignSessionModal", () => {
   it("shows validation error when submitting without session", async () => {
     render(<AssignSessionModal {...defaultProps} />);
     // The button should be disabled since no session/date selected
-    expect(screen.getByText("Assign Session")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "ASSIGN SESSION" })).toBeDisabled();
   });
 
   it("submits with correct payload", async () => {
@@ -108,7 +108,7 @@ describe("AssignSessionModal", () => {
     } as Response);
 
     // Submit
-    await userEvent.click(screen.getByText("Assign Session"));
+    await userEvent.click(screen.getByText("ASSIGN SESSION"));
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
@@ -133,9 +133,9 @@ describe("AssignSessionModal", () => {
     await userEvent.type(dateInput, "2026-12-25");
 
     vi.mocked(global.fetch).mockImplementation(() => new Promise(() => {}));
-    await userEvent.click(screen.getByText("Assign Session"));
+    await userEvent.click(screen.getByText("ASSIGN SESSION"));
 
-    expect(screen.getByText("Assigning...")).toBeInTheDocument();
+    expect(screen.getByText("ASSIGNING...")).toBeInTheDocument();
   });
 
   it("displays API error message", async () => {
@@ -152,7 +152,7 @@ describe("AssignSessionModal", () => {
       json: async () => ({ error: "Already assigned" }),
     } as Response);
 
-    await userEvent.click(screen.getByText("Assign Session"));
+    await userEvent.click(screen.getByText("ASSIGN SESSION"));
 
     await waitFor(() => {
       expect(screen.getByText("Already assigned")).toBeInTheDocument();
@@ -166,7 +166,7 @@ describe("AssignSessionModal", () => {
         sessions={[makeSession({ id: "s1", status: "generating" })]}
       />
     );
-    expect(screen.getByText("Assign Session")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "ASSIGN SESSION" })).toBeDisabled();
   });
 
   it("renders due date input with min date set to tomorrow", () => {

--- a/src/components/features/AssignSessionModal.tsx
+++ b/src/components/features/AssignSessionModal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Modal } from "@/components";
+import { Modal } from "@/components";
+import { BrutalistButton, themeTokens } from "@/components/ui/dashboard-primitives";
 import type { PrimingSessionListItem } from "@/lib/types/priming-session";
 
 interface AssignSessionModalProps {
@@ -11,6 +12,7 @@ interface AssignSessionModalProps {
   sessions: PrimingSessionListItem[];
   assignedSessionIds: Set<string>;
   onAssigned: () => void;
+  isDark?: boolean;
 }
 
 export default function AssignSessionModal({
@@ -20,7 +22,9 @@ export default function AssignSessionModal({
   sessions,
   assignedSessionIds,
   onAssigned,
+  isDark = true,
 }: Readonly<AssignSessionModalProps>) {
+  const t = themeTokens(isDark);
   const [selectedSessionId, setSelectedSessionId] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -84,7 +88,7 @@ export default function AssignSessionModal({
 
   return (
     <Modal open={open} onOpenChange={handleClose}>
-      <Modal.Content size="md">
+      <Modal.Content size="md" isDark={isDark}>
         <Modal.Title>Assign Session to Students</Modal.Title>
         <Modal.Description>
           Select a completed priming session and set a due date for your
@@ -94,11 +98,11 @@ export default function AssignSessionModal({
         <div className="mt-6 space-y-6">
           {/* Session selector */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
+            <label className={`mb-2 block font-mono text-[10px] ${t.textDim} tracking-[0.25em] uppercase`}>
               Priming Session
             </label>
             {availableSessions.length === 0 ? (
-              <p className="text-sm text-gray-500">
+              <p className={`font-mono text-xs ${t.textMid}`}>
                 No unassigned completed sessions available. Create and complete
                 a priming session first.
               </p>
@@ -106,12 +110,12 @@ export default function AssignSessionModal({
               <select
                 value={selectedSessionId}
                 onChange={(e) => setSelectedSessionId(e.target.value)}
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-black focus:outline-none focus:ring-1 focus:ring-black"
+                className={`w-full border ${t.border} bg-transparent ${t.text} font-mono text-sm px-4 py-3 focus:outline-none focus:border-current transition-colors duration-200`}
                 disabled={isLoading}
               >
-                <option value="">Select a session...</option>
+                <option value="" className={isDark ? "bg-black" : "bg-white"}>Select a session...</option>
                 {availableSessions.map((session) => (
-                  <option key={session.id} value={session.id}>
+                  <option key={session.id} value={session.id} className={isDark ? "bg-black" : "bg-white"}>
                     {session.title || session.lecture_name || "Untitled session"}
                     {session.duration ? ` (${session.duration} min)` : ""}
                   </option>
@@ -122,7 +126,7 @@ export default function AssignSessionModal({
 
           {/* Due date picker */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
+            <label className={`mb-2 block font-mono text-[10px] ${t.textDim} tracking-[0.25em] uppercase`}>
               Due Date
             </label>
             <input
@@ -130,22 +134,25 @@ export default function AssignSessionModal({
               value={dueDate}
               onChange={(e) => setDueDate(e.target.value)}
               min={minDate}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-black focus:outline-none focus:ring-1 focus:ring-black"
+              className={`w-full border ${t.border} bg-transparent ${t.text} font-mono text-sm px-4 py-3 focus:outline-none focus:border-current transition-colors duration-200`}
               disabled={isLoading}
             />
           </div>
 
           {/* Error message */}
-          {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && (
+            <p className={`font-mono text-xs ${isDark ? "text-red-400" : "text-red-600"}`}>{error}</p>
+          )}
         </div>
 
         <Modal.Footer>
           <Modal.Close>
-            <Button variant="secondary" disabled={isLoading}>
+            <BrutalistButton isDark={isDark} variant="secondary" disabled={isLoading}>
               Cancel
-            </Button>
+            </BrutalistButton>
           </Modal.Close>
-          <Button
+          <BrutalistButton
+            isDark={isDark}
             onClick={handleSubmit}
             disabled={
               isLoading ||
@@ -154,8 +161,8 @@ export default function AssignSessionModal({
               availableSessions.length === 0
             }
           >
-            {isLoading ? "Assigning..." : "Assign Session"}
-          </Button>
+            {isLoading ? "ASSIGNING..." : "ASSIGN SESSION"}
+          </BrutalistButton>
         </Modal.Footer>
       </Modal.Content>
     </Modal>

--- a/src/components/features/CreateCourseModal.test.tsx
+++ b/src/components/features/CreateCourseModal.test.tsx
@@ -38,7 +38,7 @@ describe("CreateCourseModal", () => {
   it("renders Cancel and Create Course buttons", () => {
     render(<CreateCourseModal {...defaultProps} />);
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Create Course" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "CREATE COURSE" })).toBeInTheDocument();
   });
 
   it("shows validation error when required fields are missing", async () => {
@@ -72,7 +72,7 @@ describe("CreateCourseModal", () => {
     await userEvent.type(screen.getByLabelText("Course Title"), "Introduction to Psychology");
     await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
     await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
-    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "CREATE COURSE" }));
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/courses", expect.objectContaining({
@@ -97,7 +97,7 @@ describe("CreateCourseModal", () => {
     await userEvent.type(screen.getByLabelText("Course Title"), "Psych 101");
     await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
     await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
-    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "CREATE COURSE" }));
 
     await waitFor(() => {
       expect(defaultProps.onCourseCreated).toHaveBeenCalled();
@@ -115,7 +115,7 @@ describe("CreateCourseModal", () => {
     await userEvent.type(screen.getByLabelText("Course Title"), "Psych 101");
     await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
     await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
-    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "CREATE COURSE" }));
 
     await waitFor(() => {
       expect(screen.getByText("Course code already exists")).toBeInTheDocument();
@@ -129,7 +129,7 @@ describe("CreateCourseModal", () => {
     await userEvent.type(screen.getByLabelText("Course Title"), "Psych 101");
     await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
     await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
-    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "CREATE COURSE" }));
 
     await waitFor(() => {
       expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
@@ -143,9 +143,9 @@ describe("CreateCourseModal", () => {
     await userEvent.type(screen.getByLabelText("Course Title"), "Psych 101");
     await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
     await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
-    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "CREATE COURSE" }));
 
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.getByText("LOADING...")).toBeInTheDocument();
   });
 
   it("includes description in fetch body when provided", async () => {
@@ -159,7 +159,7 @@ describe("CreateCourseModal", () => {
     await userEvent.type(screen.getByLabelText("Description"), "A course about psychology");
     await userEvent.type(screen.getByLabelText("Course Code"), "PSY 101");
     await userEvent.type(screen.getByLabelText("Semester"), "Fall 2026");
-    await userEvent.click(screen.getByRole("button", { name: "Create Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "CREATE COURSE" }));
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/courses", expect.objectContaining({

--- a/src/components/features/CreateCourseModal.tsx
+++ b/src/components/features/CreateCourseModal.tsx
@@ -1,19 +1,23 @@
 "use client";
 
 import { useState, useEffect, FormEvent } from "react";
-import { Button, Input, Modal } from "@/components";
+import { Modal } from "@/components";
+import { BrutalistButton, BrutalistInput, themeTokens } from "@/components/ui/dashboard-primitives";
 
 interface CreateCourseModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCourseCreated: () => void;
+  isDark?: boolean;
 }
 
 export default function CreateCourseModal({
   open,
   onOpenChange,
   onCourseCreated,
+  isDark = true,
 }: Readonly<CreateCourseModalProps>) {
+  const t = themeTokens(isDark);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [courseCode, setCourseCode] = useState("");
@@ -73,14 +77,16 @@ export default function CreateCourseModal({
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      <Modal.Content size="md">
+      <Modal.Content size="md" isDark={isDark}>
         <Modal.Title>Create Course</Modal.Title>
         <Modal.Description>
           Fill in the details below to create a new course.
         </Modal.Description>
 
         <form onSubmit={handleSubmit} className="mt-6 space-y-4">
-          <Input
+          <BrutalistInput
+            isDark={isDark}
+            id="course-title"
             label="Course Title"
             placeholder="e.g. Introduction to Psychology"
             value={title}
@@ -88,11 +94,8 @@ export default function CreateCourseModal({
             required
           />
 
-          <div className="flex flex-col gap-1">
-            <label
-              htmlFor="course-description"
-              className="text-sm font-medium text-gray-700"
-            >
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="course-description" className={`font-mono text-[10px] ${t.textDim} tracking-[0.25em] uppercase`}>
               Description
             </label>
             <textarea
@@ -101,19 +104,23 @@ export default function CreateCourseModal({
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
-              className="rounded-lg border border-gray-300 px-3 py-2 text-sm transition-colors placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent resize-none"
+              className={`w-full border ${t.border} bg-transparent ${t.text} font-mono text-sm px-4 py-3 placeholder:opacity-30 focus:outline-none focus:border-current transition-colors duration-200 resize-none`}
             />
           </div>
 
           <div className="grid grid-cols-2 gap-4">
-            <Input
+            <BrutalistInput
+              isDark={isDark}
+              id="course-code"
               label="Course Code"
               placeholder="e.g. PSY 101"
               value={courseCode}
               onChange={(e) => setCourseCode(e.target.value)}
               required
             />
-            <Input
+            <BrutalistInput
+              isDark={isDark}
+              id="course-semester"
               label="Semester"
               placeholder="e.g. Fall 2026"
               value={semester}
@@ -123,18 +130,18 @@ export default function CreateCourseModal({
           </div>
 
           {error && (
-            <p className="text-sm text-red-500">{error}</p>
+            <p className={`font-mono text-xs ${isDark ? "text-red-400" : "text-red-600"}`}>{error}</p>
           )}
 
           <Modal.Footer>
             <Modal.Close>
-              <Button type="button" variant="secondary">
+              <BrutalistButton type="button" isDark={isDark} variant="secondary" disabled={isSubmitting}>
                 Cancel
-              </Button>
+              </BrutalistButton>
             </Modal.Close>
-            <Button type="submit" isLoading={isSubmitting}>
-              Create Course
-            </Button>
+            <BrutalistButton type="submit" isDark={isDark} isLoading={isSubmitting}>
+              CREATE COURSE
+            </BrutalistButton>
           </Modal.Footer>
         </form>
       </Modal.Content>

--- a/src/components/features/CreateSessionModal.test.tsx
+++ b/src/components/features/CreateSessionModal.test.tsx
@@ -95,7 +95,7 @@ describe("CreateSessionModal", () => {
       expect(screen.getByText("15 min")).toBeInTheDocument();
     });
     const btn15 = screen.getByText("15 min").closest("button")!;
-    expect(btn15.className).toContain("border-black");
+    expect(btn15.className).toContain("border-white");
   });
 
   it("submits with correct payload on success", async () => {
@@ -120,7 +120,7 @@ describe("CreateSessionModal", () => {
     } as Response);
 
     // Click Create Session
-    await userEvent.click(screen.getByText("Create Session"));
+    await userEvent.click(screen.getByText("CREATE SESSION"));
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
@@ -147,9 +147,9 @@ describe("CreateSessionModal", () => {
     await userEvent.selectOptions(select, "L1");
 
     vi.mocked(global.fetch).mockImplementation(() => new Promise(() => {}));
-    await userEvent.click(screen.getByText("Create Session"));
+    await userEvent.click(screen.getByText("CREATE SESSION"));
 
-    expect(screen.getByText("Creating...")).toBeInTheDocument();
+    expect(screen.getByText("CREATING...")).toBeInTheDocument();
   });
 
   it("displays API error message", async () => {
@@ -168,7 +168,7 @@ describe("CreateSessionModal", () => {
       json: async () => ({ error: "Material not found" }),
     } as Response);
 
-    await userEvent.click(screen.getByText("Create Session"));
+    await userEvent.click(screen.getByText("CREATE SESSION"));
 
     await waitFor(() => {
       expect(screen.getByText("Material not found")).toBeInTheDocument();
@@ -187,7 +187,7 @@ describe("CreateSessionModal", () => {
     await userEvent.selectOptions(select, "L1");
 
     vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Network error"));
-    await userEvent.click(screen.getByText("Create Session"));
+    await userEvent.click(screen.getByText("CREATE SESSION"));
 
     await waitFor(() => {
       expect(screen.getByText("Network error")).toBeInTheDocument();
@@ -202,6 +202,6 @@ describe("CreateSessionModal", () => {
       expect(screen.getByText(/No lecture groups found/)).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Create Session")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "CREATE SESSION" })).toBeDisabled();
   });
 });

--- a/src/components/features/CreateSessionModal.tsx
+++ b/src/components/features/CreateSessionModal.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Button, Modal } from "@/components";
+import { Modal } from "@/components";
+import { BrutalistButton, themeTokens } from "@/components/ui/dashboard-primitives";
 
 interface CreateSessionModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   courseId: string;
   onCreated: () => void;
+  isDark?: boolean;
 }
 
 interface DurationOption {
@@ -39,7 +41,9 @@ export default function CreateSessionModal({
   onOpenChange,
   courseId,
   onCreated,
+  isDark = true,
 }: Readonly<CreateSessionModalProps>) {
+  const t = themeTokens(isDark);
   const [lectureNames, setLectureNames] = useState<string[]>([]);
   const [selectedLecture, setSelectedLecture] = useState("");
   const [selectedDuration, setSelectedDuration] = useState<10 | 15 | 30>(15);
@@ -116,7 +120,7 @@ export default function CreateSessionModal({
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      <Modal.Content size="md">
+      <Modal.Content size="md" isDark={isDark}>
         <Modal.Title>Create Priming Session</Modal.Title>
         <Modal.Description>
           Select a lecture group and session duration to generate a priming
@@ -126,13 +130,13 @@ export default function CreateSessionModal({
         <div className="mt-6 space-y-6">
           {/* Lecture group selector */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
+            <label className={`mb-2 block font-mono text-[10px] ${t.textDim} tracking-[0.25em] uppercase`}>
               Lecture Group
             </label>
             {isFetching ? (
-              <p className="text-sm text-gray-400">Loading lectures...</p>
+              <p className={`font-mono text-xs ${t.textMid}`}>Loading lectures...</p>
             ) : lectureNames.length === 0 ? (
-              <p className="text-sm text-gray-500">
+              <p className={`font-mono text-xs ${t.textMid}`}>
                 No lecture groups found. Upload PDF materials with a lecture name
                 first.
               </p>
@@ -140,12 +144,12 @@ export default function CreateSessionModal({
               <select
                 value={selectedLecture}
                 onChange={(e) => setSelectedLecture(e.target.value)}
-                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-black focus:outline-none focus:ring-1 focus:ring-black"
+                className={`w-full border ${t.border} bg-transparent ${t.text} font-mono text-sm px-4 py-3 focus:outline-none focus:border-current transition-colors duration-200`}
                 disabled={isLoading}
               >
-                <option value="">Select a lecture...</option>
+                <option value="" className={isDark ? "bg-black" : "bg-white"}>Select a lecture...</option>
                 {lectureNames.map((name) => (
-                  <option key={name} value={name}>
+                  <option key={name} value={name} className={isDark ? "bg-black" : "bg-white"}>
                     {name}
                   </option>
                 ))}
@@ -155,7 +159,7 @@ export default function CreateSessionModal({
 
           {/* Duration selector */}
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
+            <label className={`mb-2 block font-mono text-[10px] ${t.textDim} tracking-[0.25em] uppercase`}>
               Session Duration
             </label>
             <div className="grid grid-cols-3 gap-3">
@@ -165,16 +169,16 @@ export default function CreateSessionModal({
                   type="button"
                   onClick={() => setSelectedDuration(option.value)}
                   disabled={isLoading}
-                  className={`rounded-lg border-2 p-3 text-left transition-colors ${
+                  className={`border-2 p-3 text-left transition-colors duration-200 ${
                     selectedDuration === option.value
-                      ? "border-black bg-gray-50"
-                      : "border-gray-200 hover:border-gray-300"
+                      ? `${t.borderFull} ${t.cardBg}`
+                      : `${t.border} ${isDark ? "hover:border-white/30" : "hover:border-black/25"}`
                   }`}
                 >
-                  <p className="text-sm font-semibold text-gray-900">
+                  <p className={`font-mono text-sm font-bold tracking-wider ${t.text}`}>
                     {option.label}
                   </p>
-                  <p className="mt-1 text-xs leading-snug text-gray-500">
+                  <p className={`mt-1 font-mono text-[10px] leading-snug ${t.textMid}`}>
                     {option.description}
                   </p>
                 </button>
@@ -183,21 +187,24 @@ export default function CreateSessionModal({
           </div>
 
           {/* Error message */}
-          {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && (
+            <p className={`font-mono text-xs ${isDark ? "text-red-400" : "text-red-600"}`}>{error}</p>
+          )}
         </div>
 
         <Modal.Footer>
           <Modal.Close>
-            <Button variant="secondary" disabled={isLoading}>
+            <BrutalistButton isDark={isDark} variant="secondary" disabled={isLoading}>
               Cancel
-            </Button>
+            </BrutalistButton>
           </Modal.Close>
-          <Button
+          <BrutalistButton
+            isDark={isDark}
             onClick={handleSubmit}
             disabled={isLoading || !selectedLecture || lectureNames.length === 0}
           >
-            {isLoading ? "Creating..." : "Create Session"}
-          </Button>
+            {isLoading ? "CREATING..." : "CREATE SESSION"}
+          </BrutalistButton>
         </Modal.Footer>
       </Modal.Content>
     </Modal>

--- a/src/components/features/EnrollCourseModal.test.tsx
+++ b/src/components/features/EnrollCourseModal.test.tsx
@@ -33,7 +33,7 @@ describe("EnrollCourseModal", () => {
   it("renders Cancel and Join Course buttons", () => {
     render(<EnrollCourseModal {...defaultProps} />);
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Join Course" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "JOIN COURSE" })).toBeInTheDocument();
   });
 
   it("shows error when invitation code is empty", async () => {
@@ -49,7 +49,7 @@ describe("EnrollCourseModal", () => {
   it("shows error when invitation code is too short (< 6 chars)", async () => {
     render(<EnrollCourseModal {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Invitation Code"), "ABC");
-    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "JOIN COURSE" }));
     await waitFor(() => {
       expect(screen.getByText("Invitation code must be at least 6 characters.")).toBeInTheDocument();
     });
@@ -69,7 +69,7 @@ describe("EnrollCourseModal", () => {
 
     render(<EnrollCourseModal {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
-    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "JOIN COURSE" }));
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/enrollments", expect.objectContaining({
@@ -87,7 +87,7 @@ describe("EnrollCourseModal", () => {
 
     render(<EnrollCourseModal {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
-    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "JOIN COURSE" }));
 
     await waitFor(() => {
       expect(defaultProps.onEnrolled).toHaveBeenCalled();
@@ -103,7 +103,7 @@ describe("EnrollCourseModal", () => {
 
     render(<EnrollCourseModal {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Invitation Code"), "BADCOD");
-    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "JOIN COURSE" }));
 
     await waitFor(() => {
       expect(screen.getByText("Invalid invitation code. Please check with your teacher.")).toBeInTheDocument();
@@ -118,7 +118,7 @@ describe("EnrollCourseModal", () => {
 
     render(<EnrollCourseModal {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
-    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "JOIN COURSE" }));
 
     await waitFor(() => {
       expect(screen.getByText("You are already enrolled in this course.")).toBeInTheDocument();
@@ -130,7 +130,7 @@ describe("EnrollCourseModal", () => {
 
     render(<EnrollCourseModal {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
-    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "JOIN COURSE" }));
 
     await waitFor(() => {
       expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
@@ -142,9 +142,9 @@ describe("EnrollCourseModal", () => {
 
     render(<EnrollCourseModal {...defaultProps} />);
     await userEvent.type(screen.getByLabelText("Invitation Code"), "ABCDEF");
-    await userEvent.click(screen.getByRole("button", { name: "Join Course" }));
+    await userEvent.click(screen.getByRole("button", { name: "JOIN COURSE" }));
 
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.getByText("LOADING...")).toBeInTheDocument();
   });
 
   it("resets form when modal is closed and reopened", async () => {

--- a/src/components/features/EnrollCourseModal.tsx
+++ b/src/components/features/EnrollCourseModal.tsx
@@ -1,19 +1,23 @@
 "use client";
 
 import { useState, useEffect, FormEvent } from "react";
-import { Button, Input, Modal } from "@/components";
+import { Modal } from "@/components";
+import { BrutalistButton, BrutalistInput, themeTokens } from "@/components/ui/dashboard-primitives";
 
 interface EnrollCourseModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onEnrolled: () => void;
+  isDark?: boolean;
 }
 
 export default function EnrollCourseModal({
   open,
   onOpenChange,
   onEnrolled,
+  isDark = true,
 }: Readonly<EnrollCourseModalProps>) {
+  const t = themeTokens(isDark);
   const [invitationCode, setInvitationCode] = useState("");
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -69,16 +73,18 @@ export default function EnrollCourseModal({
 
   return (
     <Modal open={open} onOpenChange={onOpenChange}>
-      <Modal.Content size="sm">
+      <Modal.Content size="sm" isDark={isDark}>
         <Modal.Title>Enroll in Course</Modal.Title>
         <Modal.Description>
           Enter the invitation code from your teacher to join a course.
         </Modal.Description>
 
         <form onSubmit={handleSubmit} className="mt-6 space-y-4">
-          <Input
+          <BrutalistInput
+            isDark={isDark}
+            id="invitation-code"
             label="Invitation Code"
-            placeholder="Enter code"
+            placeholder="ENTER CODE"
             value={invitationCode}
             onChange={(e) => setInvitationCode(e.target.value.toUpperCase())}
             maxLength={8}
@@ -86,23 +92,23 @@ export default function EnrollCourseModal({
             className="text-center text-lg tracking-widest uppercase"
             required
           />
-          <p className="text-xs text-gray-500 text-center">
+          <p className={`font-mono text-[10px] ${t.textDim} tracking-wider text-center`}>
             Ask your teacher for the course invitation code
           </p>
 
           {error && (
-            <p className="text-sm text-red-500">{error}</p>
+            <p className={`font-mono text-xs ${isDark ? "text-red-400" : "text-red-600"}`}>{error}</p>
           )}
 
           <Modal.Footer>
             <Modal.Close>
-              <Button type="button" variant="secondary">
+              <BrutalistButton type="button" isDark={isDark} variant="secondary" disabled={isSubmitting}>
                 Cancel
-              </Button>
+              </BrutalistButton>
             </Modal.Close>
-            <Button type="submit" isLoading={isSubmitting}>
-              Join Course
-            </Button>
+            <BrutalistButton type="submit" isDark={isDark} isLoading={isSubmitting}>
+              JOIN COURSE
+            </BrutalistButton>
           </Modal.Footer>
         </form>
       </Modal.Content>

--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -102,7 +102,7 @@ describe("Modal", () => {
       </Modal>
     );
     const title = screen.getByText("My Modal");
-    expect(title.className).toMatch(/font-semibold/);
+    expect(title.className).toMatch(/font-mono/);
   });
 
   it("renders Modal.Close wrapping a button that triggers onOpenChange", async () => {

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { forwardRef } from "react";
+import { createContext, forwardRef, useContext } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
+import { CornerAccents, themeTokens } from "@/components/ui/dashboard-primitives";
+
+/* ------------------------------------------------------------------ */
+/*  Internal theme context                                             */
+/* ------------------------------------------------------------------ */
+
+const ModalThemeContext = createContext<boolean>(true);
 
 /* ------------------------------------------------------------------ */
 /*  Modal (root)                                                       */
@@ -42,6 +49,8 @@ ModalTrigger.displayName = "Modal.Trigger";
 interface ModalContentProps extends Dialog.DialogContentProps {
   /** Width preset. Defaults to "md". */
   size?: "sm" | "md" | "lg";
+  /** Match the dashboard theme. Defaults to true (dark). */
+  isDark?: boolean;
 }
 
 const sizeStyles: Record<string, string> = {
@@ -51,44 +60,53 @@ const sizeStyles: Record<string, string> = {
 };
 
 const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
-  ({ children, className = "", size = "md", ...props }, ref) => (
-    <Dialog.Portal>
-      {/* Overlay */}
-      <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+  ({ children, className = "", size = "md", isDark = true, ...props }, ref) => {
+    const t = themeTokens(isDark);
+    return (
+      <ModalThemeContext.Provider value={isDark}>
+        <Dialog.Portal>
+          {/* Overlay */}
+          <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
 
-      {/* Panel */}
-      <Dialog.Content
-        ref={ref}
-        className={`fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-gray-200 bg-white p-6 shadow-xl focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 ${sizeStyles[size]} ${className}`}
-        {...props}
-      >
-        {children}
-
-        {/* Close button */}
-        <Dialog.Close
-          aria-label="Close"
-          className="absolute right-4 top-4 rounded-md p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
+          {/* Panel */}
+          <Dialog.Content
+            ref={ref}
+            className={`fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 border ${t.border} ${isDark ? "bg-black" : "bg-white"} p-6 focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 ${sizeStyles[size]} ${className}`}
+            {...props}
           >
-            <path
-              d="M12.5 3.5L3.5 12.5M3.5 3.5L12.5 12.5"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </Dialog.Close>
-      </Dialog.Content>
-    </Dialog.Portal>
-  )
+            <CornerAccents isDark={isDark} />
+
+            <div className="relative z-10">
+              {children}
+            </div>
+
+            {/* Close button */}
+            <Dialog.Close
+              aria-label="Close"
+              className={`absolute right-4 top-4 border ${t.border} p-1 ${t.textMid} transition-colors duration-200 ${isDark ? "hover:border-white/40 hover:text-white" : "hover:border-black/40 hover:text-black"} focus-visible:outline-none`}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12.5 3.5L3.5 12.5M3.5 3.5L12.5 12.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </ModalThemeContext.Provider>
+    );
+  }
 );
 ModalContent.displayName = "Modal.Content";
 
@@ -99,15 +117,19 @@ ModalContent.displayName = "Modal.Content";
 const ModalTitle = forwardRef<
   HTMLHeadingElement,
   Dialog.DialogTitleProps
->(({ children, className = "", ...props }, ref) => (
-  <Dialog.Title
-    ref={ref}
-    className={`text-lg font-semibold text-gray-900 ${className}`}
-    {...props}
-  >
-    {children}
-  </Dialog.Title>
-));
+>(({ children, className = "", ...props }, ref) => {
+  const isDark = useContext(ModalThemeContext);
+  const t = themeTokens(isDark);
+  return (
+    <Dialog.Title
+      ref={ref}
+      className={`font-mono text-sm font-bold tracking-[0.2em] uppercase ${t.text} ${className}`}
+      {...props}
+    >
+      {children}
+    </Dialog.Title>
+  );
+});
 ModalTitle.displayName = "Modal.Title";
 
 /* ------------------------------------------------------------------ */
@@ -117,15 +139,19 @@ ModalTitle.displayName = "Modal.Title";
 const ModalDescription = forwardRef<
   HTMLParagraphElement,
   Dialog.DialogDescriptionProps
->(({ children, className = "", ...props }, ref) => (
-  <Dialog.Description
-    ref={ref}
-    className={`mt-1 text-sm text-gray-500 ${className}`}
-    {...props}
-  >
-    {children}
-  </Dialog.Description>
-));
+>(({ children, className = "", ...props }, ref) => {
+  const isDark = useContext(ModalThemeContext);
+  const t = themeTokens(isDark);
+  return (
+    <Dialog.Description
+      ref={ref}
+      className={`mt-1 font-mono text-xs ${t.textMid} ${className}`}
+      {...props}
+    >
+      {children}
+    </Dialog.Description>
+  );
+});
 ModalDescription.displayName = "Modal.Description";
 
 /* ------------------------------------------------------------------ */
@@ -137,9 +163,11 @@ interface ModalFooterProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 function ModalFooter({ children, className = "", ...props }: Readonly<ModalFooterProps>) {
+  const isDark = useContext(ModalThemeContext);
+  const t = themeTokens(isDark);
   return (
     <div
-      className={`mt-6 flex items-center justify-end gap-2 ${className}`}
+      className={`mt-6 pt-4 border-t ${t.border} flex items-center justify-end gap-3 ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/dashboard-primitives.tsx
+++ b/src/components/ui/dashboard-primitives.tsx
@@ -189,7 +189,7 @@ interface BrutalistInputProps extends React.InputHTMLAttributes<HTMLInputElement
 }
 
 export const BrutalistInput = forwardRef<HTMLInputElement, BrutalistInputProps>(
-  function BrutalistInput({ isDark, label, error, className = "", ...rest }, ref) {
+  function BrutalistInput({ isDark, label, error, id, className = "", ...rest }, ref) {
     const t = themeTokens(isDark);
     const errorBorder = isDark ? 'border-red-500/40' : 'border-red-500/60';
     const errorText = isDark ? 'text-red-400' : 'text-red-600';
@@ -197,11 +197,12 @@ export const BrutalistInput = forwardRef<HTMLInputElement, BrutalistInputProps>(
     return (
       <div className="flex flex-col gap-1.5">
         {label && (
-          <label className={`font-mono text-[10px] ${t.textDim} tracking-[0.25em] uppercase`}>
+          <label htmlFor={id} className={`font-mono text-[10px] ${t.textDim} tracking-[0.25em] uppercase`}>
             {label}
           </label>
         )}
         <input
+          id={id}
           ref={ref}
           className={`w-full border ${error ? errorBorder : t.border} bg-transparent ${t.text} font-mono text-sm px-4 py-3 placeholder:${isDark ? 'text-white/20' : 'text-black/25'} focus:outline-none focus:border-current transition-colors duration-200 ${className}`}
           {...rest}


### PR DESCRIPTION
Replace rounded/shadowed modal styles with the app's brutalist aesthetic: sharp borders, font-mono, corner accents, and full dark/light theme support via isDark prop threaded from DashboardThemeContext. Swap Button/Input for BrutalistButton/ BrutalistInput across all feature modals. Update tests to reflect new button text casing, loading states, and accessible label associations.